### PR TITLE
Fix typos and update video embeds in blade templates

### DIFF
--- a/resources/views/actions-tem.blade.php
+++ b/resources/views/actions-tem.blade.php
@@ -139,7 +139,7 @@
                     <li>Un service Communication</li>
                     <li>Une résidence d’artiste par an</li>
                     <li>5 concerts par an</li>
-                    <li>1 clip vidé</li>
+                    <li>1 clip vidéo</li>
                     <li>Pour une jauge annuelle de 2000 personnes…</li>
                 </ul>
             </div>

--- a/resources/views/index.blade.php
+++ b/resources/views/index.blade.php
@@ -53,8 +53,6 @@
 
             <div class="row s-about__content width-sixteen-col">
                 <div class="column grid-block grid-section-split">
-
-
                     <div class="section-header grid-section-split__header">
                         <div class="text-pretitle">A propos</div>
                         <h2 class="text-display-title">
@@ -121,12 +119,25 @@
 
             </div>
             <div class="row width-sixteen-col">
-                <div class="flex flex-col md:flex-row space-y-4 md:space-y-0 md:space-x-4 mt-4">
+                <div class="flex flex-col md:flex-row space-y-4 md:space-y-0 md:space-x-4 mt-4 w-full items-center justify-center">
                     <div class="flex-1 mx-5">
-                        <video class="w-full h-full rounded-lg" src="{{ asset('asset/videos/interviews_TEM15.mov') }}" controls></video>
+                        <iframe
+                            class="w-full aspect-video rounded-lg"
+                            src="https://www.youtube.com/embed/lj2jc_aVSbE?modestbranding=1&rel=0&showinfo=0"
+                            title="TEM15 - De Brunoy à Angers"
+                            allow="accelerometer; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share"
+                            allowfullscreen>
+                        </iframe>
                     </div>
+
                     <div class="flex-1 mx-5">
-                        <video class="w-full h-full rounded-lg" src="{{ asset('asset/videos/TEM15_Brunoy_Angers.mp4') }}" controls></video>
+                        <iframe
+                            class="w-full aspect-video rounded-lg"
+                            src="https://www.youtube.com/embed/oAoiPOl_Hkc?modestbranding=1&rel=0&showinfo=0"
+                            title="Interviews TEM15 - membres de l'association"
+                            allow="accelerometer; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share"
+                            allowfullscreen>
+                        </iframe>
                     </div>
                 </div>
             </div>


### PR DESCRIPTION
This pull request makes minor corrections and improves the user experience on the homepage by replacing local video files with embedded YouTube videos and making a small text fix. The most significant changes are grouped below:

Homepage video improvements:

* Replaced two locally hosted `<video>` elements with embedded YouTube `<iframe>` players in `index.blade.php` for better compatibility and streaming performance. Also adjusted the container div to center the videos and ensure they are responsive.

Minor corrections:

* Fixed a typo in `actions-tem.blade.php`, correcting "clip vidé" to "clip vidéo".
* Removed two unnecessary blank lines from `index.blade.php` for cleaner code formatting.