### PR TITLE
Update video embeds to use YouTube no-cookie URLs and add referrer po…

### DIFF
--- a/resources/views/index.blade.php
+++ b/resources/views/index.blade.php
@@ -123,7 +123,8 @@
                     <div class="flex-1 mx-5">
                         <iframe
                             class="w-full aspect-video rounded-lg"
-                            src="https://www.youtube.com/embed/lj2jc_aVSbE?modestbranding=1&rel=0&showinfo=0"
+                            src="https://www.youtube-nocookie.com/embed/lj2jc_aVSbE?modestbranding=1&rel=0&showinfo=0"
+                            referrerpolicy="strict-origin-when-cross-origin"
                             title="TEM15 - De Brunoy à Angers"
                             allow="accelerometer; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share"
                             allowfullscreen>
@@ -133,7 +134,8 @@
                     <div class="flex-1 mx-5">
                         <iframe
                             class="w-full aspect-video rounded-lg"
-                            src="https://www.youtube.com/embed/oAoiPOl_Hkc?modestbranding=1&rel=0&showinfo=0"
+                            src="https://www.youtube-nocookie.com/embed/oAoiPOl_Hkc?modestbranding=1&rel=0&showinfo=0"
+                            referrerpolicy="strict-origin-when-cross-origin"
                             title="Interviews TEM15 - membres de l'association"
                             allow="accelerometer; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share"
                             allowfullscreen>


### PR DESCRIPTION
This pull request updates the embedded YouTube videos in the `index.blade.php` view to enhance privacy and security. The main changes are switching to the privacy-enhanced `youtube-nocookie.com` domain and adding a stricter referrer policy for the video iframes.

**Embedded video privacy and security improvements:**

* Updated the `src` attribute of both embedded YouTube videos to use the `youtube-nocookie.com` domain for enhanced privacy. [[1]](diffhunk://#diff-e6a72274bd2be1ba8cf26cb930f07d9c65cf4329bfc5f832779d8be3129ea3c6L126-R127) [[2]](diffhunk://#diff-e6a72274bd2be1ba8cf26cb930f07d9c65cf4329bfc5f832779d8be3129ea3c6L136-R138)
* Added the `referrerpolicy="strict-origin-when-cross-origin"` attribute to both video iframes to further protect user privacy. [[1]](diffhunk://#diff-e6a72274bd2be1ba8cf26cb930f07d9c65cf4329bfc5f832779d8be3129ea3c6L126-R127) [[2]](diffhunk://#diff-e6a72274bd2be1ba8cf26cb930f07d9c65cf4329bfc5f832779d8be3129ea3c6L136-R138)