### PR TITLE
Update video embeds to use standard YouTube URLs and adjust allow attributes

### DIFF
--- a/resources/views/index.blade.php
+++ b/resources/views/index.blade.php
@@ -123,10 +123,9 @@
                     <div class="flex-1 mx-5">
                         <iframe
                             class="w-full aspect-video rounded-lg"
-                            src="https://www.youtube-nocookie.com/embed/lj2jc_aVSbE?modestbranding=1&rel=0&showinfo=0"
-                            referrerpolicy="strict-origin-when-cross-origin"
+                            src="https://www.youtube.com/embed/lj2jc_aVSbE?modestbranding=1&rel=0&showinfo=0"
                             title="TEM15 - De Brunoy à Angers"
-                            allow="accelerometer; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share"
+                            allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share"
                             allowfullscreen>
                         </iframe>
                     </div>
@@ -134,10 +133,9 @@
                     <div class="flex-1 mx-5">
                         <iframe
                             class="w-full aspect-video rounded-lg"
-                            src="https://www.youtube-nocookie.com/embed/oAoiPOl_Hkc?modestbranding=1&rel=0&showinfo=0"
-                            referrerpolicy="strict-origin-when-cross-origin"
+                            src="https://www.youtube.com/embed/oAoiPOl_Hkc?modestbranding=1&rel=0&showinfo=0"
                             title="Interviews TEM15 - membres de l'association"
-                            allow="accelerometer; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share"
+                            allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share"
                             allowfullscreen>
                         </iframe>
                     </div>


### PR DESCRIPTION
This pull request updates the embedded YouTube video iframes in the `index.blade.php` view. The main changes are switching from the privacy-enhanced `youtube-nocookie.com` domain to the standard `youtube.com` domain for the video sources, and enabling the `autoplay` permission for the videos.

Video embed updates:

* Changed the `src` attribute of both video iframes from `youtube-nocookie.com` to `youtube.com`, which may affect user privacy and cookie behavior.
* Added `autoplay` to the `allow` attribute for both video iframes, enabling videos to play automatically if supported.
* Removed the `referrerpolicy="strict-origin-when-cross-origin"` attribute from both iframes.