### PR TITLE
Replace YouTube embeds with local video files in index.blade.php

### DIFF
--- a/resources/views/index.blade.php
+++ b/resources/views/index.blade.php
@@ -119,25 +119,12 @@
 
             </div>
             <div class="row width-sixteen-col">
-                <div class="flex flex-col md:flex-row space-y-4 md:space-y-0 md:space-x-4 mt-4 w-full items-center justify-center">
+                <div class="flex flex-col md:flex-row gap-4 mt-4 w-full px-4">
                     <div class="flex-1 mx-5">
-                        <iframe
-                            class="w-full aspect-video rounded-lg"
-                            src="https://www.youtube.com/embed/lj2jc_aVSbE?modestbranding=1&rel=0&showinfo=0"
-                            title="TEM15 - De Brunoy à Angers"
-                            allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share"
-                            allowfullscreen>
-                        </iframe>
+                        <video class="w-full h-full rounded-lg" src="{{ asset('asset/videos/interviews_TEM15.mp4') }}" controls></video>
                     </div>
-
                     <div class="flex-1 mx-5">
-                        <iframe
-                            class="w-full aspect-video rounded-lg"
-                            src="https://www.youtube.com/embed/oAoiPOl_Hkc?modestbranding=1&rel=0&showinfo=0"
-                            title="Interviews TEM15 - membres de l'association"
-                            allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share"
-                            allowfullscreen>
-                        </iframe>
+                        <video class="w-full h-full rounded-lg" src="{{ asset('asset/videos/TEM15_Brunoy_Angers.mp4') }}" controls></video>
                     </div>
                 </div>
             </div>


### PR DESCRIPTION
This pull request updates the way videos are displayed on the homepage by replacing embedded YouTube iframes with locally hosted video files using the HTML5 `video` tag. This change improves user privacy, page load speed, and control over video content.

**Video display improvements:**

* Replaced two YouTube iframe embeds with HTML5 `video` elements that play locally hosted videos (`interviews_TEM15.mp4` and `TEM15_Brunoy_Angers.mp4`) in `index.blade.php`.
* Updated the container layout to use `gap-4` and `px-4` for more consistent spacing and padding across screen sizes.