### PR TITLE
Refactor scroll down section in index.blade.php and clean up styles.css

### DIFF
--- a/public/asset/css/styles.css
+++ b/public/asset/css/styles.css
@@ -1737,11 +1737,6 @@ img.u-pull-left {
 /* --------------------------------------------------------------------
  * ## spacing
  * -------------------------------------------------------------------- */
-fieldset,
-button,
-.btn {
-    margin-bottom: var(--vspace-0_5);
-}
 
 input,
 textarea,
@@ -2164,7 +2159,6 @@ input[type=button] {
     height: var(--btn-height);
     line-height: calc(var(--btn-height) - 4px);
     padding: 0 2.6rem;
-    margin: 0 0.4rem var(--vspace-0_5) 0;
     color: var(--color-btn-text);
     text-decoration: none;
     text-align: center;
@@ -3639,10 +3633,6 @@ td:last-child {
 .s-intro__scroll-down a {
     display: inline-flex;
     color: var(--color-2-darker);
-}
-
-.s-intro__scroll-down .btn {
-    margin-left: var(--vspace-1);
 }
 
 .s-intro__scroll-down span {

--- a/resources/views/index.blade.php
+++ b/resources/views/index.blade.php
@@ -31,13 +31,19 @@
                         </div>
                     </div> <!-- s-intro__content-media -->
 
-                    <div class="s-intro__scroll-down">
+                    <div class="s-intro__scroll-down flex flex-col md:flex-row">
                         <a href="#about" class="smoothscroll">
-                            <div class="scroll-icon">
-                                <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" width="36" height="36" fill="none" stroke="#97b34a" stroke-width="1" stroke-linecap="round" stroke-linejoin="round">&lt;!--!  Atomicons Free 1.00 by @atisalab License - https://atomicons.com/license/ (Icons: CC BY 4.0) Copyright 2021 Atomicons --&gt;<polyline points="7 13 12 18 17 13"></polyline><line x1="12" y1="18" x2="12" y2="6"></line></svg>
+                            <div class="flex mr-2">
+                                <div class="scroll-icon mt-3">
+                                    <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" width="36" height="36" fill="none" stroke="#97b34a" stroke-width="1" stroke-linecap="round" stroke-linejoin="round">&lt;!--!  Atomicons Free 1.00 by @atisalab License - https://atomicons.com/license/ (Icons: CC BY 4.0) Copyright 2021 Atomicons --&gt;<polyline points="7 13 12 18 17 13"></polyline><line x1="12" y1="18" x2="12" y2="6"></line></svg>
+                                </div>
                             </div>
-                            <span>Plus d'informations</span>
-                            <a class="btn btn--primary" href="{{ route('nous-soutenir') }}"> Nous soutenir </a>
+                            <div class="flex mr-14">
+                                <span>Plus d'informations</span>
+                            </div>
+                            <div class="hidden md:flex mt-3.5">
+                                <a class="btn btn--primary" href="{{ route('nous-soutenir') }}"> Nous soutenir </a>
+                            </div>
                         </a>
                     </div> <!-- s-intro__scroll-down -->
 


### PR DESCRIPTION
This pull request updates the layout and styling of the "scroll down" section on the homepage to improve its appearance and responsiveness. The changes focus on restructuring the HTML for better alignment and removing some default button margins in the CSS to allow for more flexible custom layouts.

Layout and structure improvements:

* Refactored the `.s-intro__scroll-down` section in `index.blade.php` to use a flexbox layout, separating the scroll icon, label, and "Nous soutenir" button into distinct flex containers for improved alignment and responsiveness.

Styling adjustments:

* Removed default bottom margins from `fieldset`, `button`, and `.btn` elements in `styles.css` to prevent unwanted spacing and allow for more precise control in custom layouts.
* Removed the right and bottom margin from `input[type=button]` in `styles.css` for more consistent button spacing.
* Removed the left margin from `.s-intro__scroll-down .btn` in `styles.css` to align the button properly within the new flex layout.